### PR TITLE
fix depreciated call go get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 FROM golang:alpine as build
 
 ENV GOOS=linux \
-    GOARCH=amd64 
+    GOARCH=amd64
 
 RUN apk add --no-cache git
 
 WORKDIR /go/src/transmission-telegram
 COPY . .
 
+RUN go mod init transmission-telegram
 RUN go get -d -v ./...
 RUN go install -v ./...
 
 RUN go build -o main .
+# RUN ls -lahR /go/
 
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ WORKDIR /go/src/transmission-telegram
 COPY . .
 
 RUN go mod init transmission-telegram
+RUN go mod tidy
 RUN go get -d -v ./...
 RUN go install -v ./...
 
 RUN go build -o main .
-# RUN ls -lahR /go/
 
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates


### PR DESCRIPTION
The current state of the Dockerfile in the repo using the master branch throws an error while building with `docker build -t test .`

```shell
Sending build context to Docker daemon  1.072MB
Step 1/15 : FROM golang:alpine as build
 ---> 0e3b02146c47
Step 2/15 : ENV GOOS=linux     GOARCH=amd64
 ---> Using cache
 ---> fddfa233c7c3
Step 3/15 : RUN apk add --no-cache git
 ---> Using cache
 ---> 7c0faa8d4389
Step 4/15 : WORKDIR /go/src/transmission-telegram
 ---> Using cache
 ---> f253f8b7b9b7
Step 5/15 : COPY . .
 ---> Using cache
 ---> e32dadf3187c
Step 6/15 : RUN go get -d -v ./...
 ---> Running in a19e1f16c925
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
The command '/bin/sh -c go get -d -v ./...' returned a non-zero code: 1
```

Looks like this is from some deprecated go commands.

I was able to fix the docker build by making these changes in the PR. I have almost 0 familiarity with golang so feel free to make any changes/requests on top of mine with more common go practices.

I've also deployed the image this new dockerfile creates to my personal docker env and the telegram bot seems to be as expected. Right now it is in dockerhub tagged as :next [kevinhalpin/transmision-telegram:next](https://hub.docker.com/layers/kevinhalpin/transmission-telegram/next/images/sha256-a501932afc5bb88b88a4a306307d96f608a025637791760225611717abfac81c?context=explore)

Output of the fixed docker build:

```
docker build --no-cache -t kevinhalpin/transmission-telegram:next . | tee ~/tmp/buildlog.log
Sending build context to Docker daemon  1.073MB

Step 1/17 : FROM golang:alpine as build
 ---> 0e3b02146c47
Step 2/17 : ENV GOOS=linux     GOARCH=amd64
 ---> Running in fcf8698aa5d5
Removing intermediate container fcf8698aa5d5
 ---> 2407634da17c
Step 3/17 : RUN apk add --no-cache git
 ---> Running in e87800560583
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
(1/6) Installing brotli-libs (1.0.9-r5)
(2/6) Installing nghttp2-libs (1.46.0-r0)
(3/6) Installing libcurl (7.80.0-r0)
(4/6) Installing expat (2.4.7-r0)
(5/6) Installing pcre2 (10.39-r0)
(6/6) Installing git (2.34.1-r0)
Executing busybox-1.34.1-r4.trigger
OK: 19 MiB in 21 packages
Removing intermediate container e87800560583
 ---> 3abfc4971178
Step 4/17 : WORKDIR /go/src/transmission-telegram
 ---> Running in 5d3670938c76
Removing intermediate container 5d3670938c76
 ---> 3cd0fb89fd1e
Step 5/17 : COPY . .
 ---> 8b8f36c7fa2f
Step 6/17 : RUN go mod init transmission-telegram
 ---> Running in 8f8b571424b8
[91mgo: creating new go.mod: module transmission-telegram
[0m[91mgo: to add module requirements and sums:
	go mod tidy
[0mRemoving intermediate container 8f8b571424b8
 ---> 32b762125f46
Step 7/17 : RUN go mod tidy
 ---> Running in f843eae1df1d
[91mgo: finding module for package gopkg.in/telegram-bot-api.v4
[0m[91mgo: finding module for package github.com/pyed/tailer
go: finding module for package github.com/pyed/transmission
[0m[91mgo: finding module for package github.com/dustin/go-humanize
[0m[91mgo: downloading gopkg.in/telegram-bot-api.v4 v4.6.4
[0m[91mgo: downloading github.com/pyed/transmission v0.0.0-20191223230952-910349eeb206
[0m[91mgo: downloading github.com/pyed/tailer v0.0.0-20190130224839-376cd2db7eb6
[0m[91mgo: downloading github.com/dustin/go-humanize v1.0.0
[0m[91mgo: found github.com/dustin/go-humanize in github.com/dustin/go-humanize v1.0.0
go: found github.com/pyed/tailer in github.com/pyed/tailer v0.0.0-20190130224839-376cd2db7eb6
go: found github.com/pyed/transmission in github.com/pyed/transmission v0.0.0-20191223230952-910349eeb206
go: found gopkg.in/telegram-bot-api.v4 in gopkg.in/telegram-bot-api.v4 v4.6.4
[0m[91mgo: finding module for package github.com/martini-contrib/auth
go: finding module for package github.com/technoweenie/multipartstreamer
go: finding module for package golang.org/x/exp/winfsnotify
go: finding module for package github.com/go-martini/martini
[0m[91mgo: downloading github.com/technoweenie/multipartstreamer v1.0.1
[0m[91mgo: downloading golang.org/x/exp v0.0.0-20220318154914-8dddf5d87bd8
[0m[91mgo: downloading github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
[0m[91mgo: downloading github.com/martini-contrib/auth v0.0.0-20150219114609-fa62c19b7ae8
[0m[91mgo: finding module for package github.com/smartystreets/goconvey/convey
[0m[91mgo: finding module for package github.com/go-telegram-bot-api/telegram-bot-api
[0m[91mgo: downloading github.com/smartystreets/goconvey v1.7.2
[0m[91mgo: downloading github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
[0m[91mgo: found golang.org/x/exp/winfsnotify in golang.org/x/exp v0.0.0-20220318154914-8dddf5d87bd8
go: found github.com/technoweenie/multipartstreamer in github.com/technoweenie/multipartstreamer v1.0.1
go: found github.com/go-martini/martini in github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
go: found github.com/martini-contrib/auth in github.com/martini-contrib/auth v0.0.0-20150219114609-fa62c19b7ae8
go: found github.com/smartystreets/goconvey/convey in github.com/smartystreets/goconvey v1.7.2
go: found github.com/go-telegram-bot-api/telegram-bot-api in github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
[0m[91mgo: downloading github.com/jtolds/gls v4.20.0+incompatible
[0m[91mgo: downloading github.com/smartystreets/assertions v1.2.0
[0m[91mgo: downloading github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
[0m[91mgo: finding module for package github.com/codegangsta/inject
[0m[91mgo: downloading github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0
[0m[91mgo: found github.com/codegangsta/inject in github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0
[0mRemoving intermediate container f843eae1df1d
 ---> 5ed6b756637b
Step 8/17 : RUN go get -d -v ./...
 ---> Running in b0081d679716
Removing intermediate container b0081d679716
 ---> abc3711be3ee
Step 9/17 : RUN go install -v ./...
 ---> Running in b8311abc2bc6
[91mgithub.com/pyed/tailer
[0m[91mgithub.com/dustin/go-humanize
[0m[91mgithub.com/pyed/transmission
github.com/technoweenie/multipartstreamer
[0m[91mgopkg.in/telegram-bot-api.v4
[0m[91mtransmission-telegram
[0mRemoving intermediate container b8311abc2bc6
 ---> 621864302b6a
Step 10/17 : RUN go build -o main .
 ---> Running in 2c3519763f00
Removing intermediate container 2c3519763f00
 ---> 9566c292e8b5
Step 11/17 : FROM alpine:latest as certs
 ---> e9adb5357e84
Step 12/17 : RUN apk --update add ca-certificates
 ---> Running in 3f679aa4f901
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
(1/1) Installing ca-certificates (20211220-r0)
Executing busybox-1.34.1-r4.trigger
Executing ca-certificates-20211220-r0.trigger
OK: 6 MiB in 15 packages
Removing intermediate container 3f679aa4f901
 ---> 0140d583487e
Step 13/17 : FROM bash:latest
latest: Pulling from library/bash
3d2430473443: Already exists
d6717c1b5263: Pulling fs layer
e904086bcdde: Pulling fs layer
e904086bcdde: Download complete
d6717c1b5263: Download complete
d6717c1b5263: Pull complete
e904086bcdde: Pull complete
Digest: sha256:ff17a9ef46a501a500c4aba4e1f3b14fde4c2a2daca32d4d26fcb1134fc9c49a
Status: Downloaded newer image for bash:latest
 ---> 36e821a45c81
Step 14/17 : COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ---> 24ea301c057d
Step 15/17 : COPY --from=build /go/bin/transmission-telegram /
 ---> a963c3641949
Step 16/17 : RUN chmod 777 transmission-telegram
 ---> Running in c22cde7dafc3
Removing intermediate container c22cde7dafc3
 ---> 7784908bdeab
Step 17/17 : ENTRYPOINT ["/transmission-telegram"]
 ---> Running in 700e2d4669c3
Removing intermediate container 700e2d4669c3
 ---> 97507d8b8bd5
Successfully built 97507d8b8bd5
Successfully tagged kevinhalpin/transmission-telegram:next
```
