### PR TITLE
Fixing the Docker image assembly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk --update add ca-certificates
 
 FROM bash:latest
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /go/bin/transmission-telegram /
+COPY --from=build /go/src/transmission-telegram/main /transmission-telegram
 RUN chmod 777 transmission-telegram
 
 ENTRYPOINT ["/transmission-telegram"]


### PR DESCRIPTION
I wanted to build an image for another architecture, but I encountered the following problem:

<img width="999" alt="Снимок экрана 2024-01-28 в 11 06 20" src="https://github.com/pyed/transmission-telegram/assets/40397740/59eda24d-35ce-45a9-babd-43affae877ce">

I suggest the following fix for this problem